### PR TITLE
fsutil.rs: Make `is_dir` return correct information

### DIFF
--- a/rust/src/fsutil.rs
+++ b/rust/src/fsutil.rs
@@ -124,7 +124,7 @@ where
 {
     fn is_dir(&self) -> bool {
         self.query_file_type(gio::FileQueryInfoFlags::NONE, gio::Cancellable::NONE)
-            == gio::FileType::SymbolicLink
+            == gio::FileType::Directory
     }
 
     fn is_regular(&self) -> bool {


### PR DESCRIPTION
`is_dir` previously returned `true`, when the object was a symbolic link instead of a directory. It now correctly returns `true` when the object is a directory.

A small patch for a small oversight I noticed when going through the code. I guess this doesn't need an issue, as I never noticed any misbehavior because of it. Apparently, the dir cache never actually was a dir cache though :-)